### PR TITLE
fix hot reloading

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "react"] 
+  "presets": ["es2015", "react", "react-hmre"] 
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-loader": "^6.2.3",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-react-hmre": "^1.1.0",
     "portfinder": "^0.4.0",
     "webpack": "^1.12.13",
     "webpack-dev-server": "^1.14.1"

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,7 @@
-import React from 'react'
-import Component from './component'
+import React, { Component } from 'react'
+import Widget from './widget'
 
-const App = () => <Component />
+class App extends Component {
+  render () { return <Widget /> }
+}
 export default App

--- a/src/component.jsx
+++ b/src/component.jsx
@@ -1,8 +1,0 @@
-import React from 'react'
-
-const Component = () => {
-  const message = "I'm your component. Have at it."
-  return (<div>{message}</div>)
-}
-
-export default Component

--- a/src/widget.jsx
+++ b/src/widget.jsx
@@ -1,0 +1,10 @@
+import React, { Component } from 'react'
+
+class Widget extends Component {
+  render () {
+    const message = "I'm your widget. Have at it."
+    return <div>{message}</div>
+  }
+}
+
+export default Widget


### PR DESCRIPTION
- fixes #11 and #12 
- moves from the now deprecated react-hot-loader to the react-transform method
- some overdue naming fixes

turns out stateless components and hot reload don't play nicely yet so the switch in #10 busted everything. also switches from Component to Widget so we can use class App extends Component instead of React.Component and avoid collisions.

hot reload for stateless functional components discussion here - 
https://github.com/gaearon/babel-plugin-react-transform/pull/34
